### PR TITLE
fix axios' catch branch return value (always undefined)

### DIFF
--- a/index.js
+++ b/index.js
@@ -44,7 +44,7 @@ module.exports = function (options) {
           };
         }).catch(function (result) {
           throw {
-            result: result.data
+            result: result
           };
         });
       };


### PR DESCRIPTION
in the `.catch` branch, `result` is an Error with following properties:
- `message`  (e.g. `Network Error`)
- `stack`  (e.g. `Error: Network Error↵    at XMLHttpRequest.handleError (http.....js:1234:12)`)
  Thus throwing `result.data` seems nonsense to me.

Comparing to its usage in the example at [README:56](https://github.com/cerebral/cerebral-module-http/blame/master/README.md#L56) (`copy('input:/result.message',...`), just throwing with the full result object seems appropriate.

NB: This fix could further be simplified using ES6 shorthand:
`throw { result }`
