### PR TITLE
toggle cerebral-url-scheme-compiler from peer to full dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,9 +21,7 @@
   },
   "homepage": "https://github.com/cerebral/cerebral-module-http#readme",
   "dependencies": {
-    "axios": "^0.9.1"
-  },
-  "peerDependency": {
+    "axios": "^0.9.1",
     "cerebral-url-scheme-compiler": "^0.3.5"
   }
 }


### PR DESCRIPTION
As of #7 , make `cerebral-url-scheme-compiler` a normal dependency instead of peerDependency for now.
This avoids build-time error, since npm does not seem to tell it at install-time.

**Future TODO**: Synchronize with [cerebral-addons](https://github.com/cerebral/cerebral-addons/blob/master/package.json#L46), which has it also as dependency.
