### PR TITLE
Fix typo in Content-Type

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,7 +12,7 @@ var DEFAULT_OPTIONS = {
   baseUrl: '',
   headers: {
     'Accept': 'application/json',
-    'Content-Type': 'application/jsoncharset=UTF-8'
+    'Content-Type': 'application/json; charset=UTF-8'
   },
   onRequest: function (xhr, options) {
     if (options.withCredentials) {


### PR DESCRIPTION
Hi!! This PR fix the typo in content-type request

Now it does

``` http
Content-Type: application/jsoncharset=UTF-8
```

And it should do

``` http
Content-Type: application/json; charset=UTF-8
```
