### PR TITLE
fix: handle missing content type in responses

### DIFF
--- a/index.js
+++ b/index.js
@@ -41,7 +41,8 @@ var DEFAULT_OPTIONS = {
   onResponse: function (xhr, resolve, reject) {
     var result = xhr.responseText
 
-    if (xhr.getResponseHeader('content-type').indexOf('application/json') >= 0) {
+    var contentType = xhr.getResponseHeader('content-type') || ''
+    if (contentType.indexOf('application/json') >= 0) {
       result = JSON.parse(xhr.responseText)
     }
 


### PR DESCRIPTION
Some endpoints might not return a content-type. In the current version it will throw because of using indexOf on null. 
